### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build Pipeline
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/CodeByLudwig/N.I.N.A-Discord-Notification/security/code-scanning/1](https://github.com/CodeByLudwig/N.I.N.A-Discord-Notification/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, since the workflow only checks out code and runs build/test commands, it only needs read access to repository contents. The best way to do this is to add a `permissions: contents: read` block at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
