### PR TITLE
Update README.md to include requirement for N.I.N.A. 3.2 in Beta Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Additionally, users can specify an image path - such as a folder where a live st
 This makes it easy to share updates and images in real time.
 The plugin also includes a trigger that can automatically create a new Discord thread and post a message after exposures, helping to keep session-related messages organized.
 
+### Beta vs Release Channel
+- Discord Notification's current versions require N.I.N.A 3.2, which is currently in the Beta release channel. Basic functionality from verison 1.0.0.1 is available in the N.I.N.A. 3.1 Release channel.
+
+
 ## Options
 - **LiveStack:**
 The LiveStack image feature needs the 'LiveStack' plugin to be installed and configured as shown in the screenshots below.


### PR DESCRIPTION
Updated to include a version note for N.I.N.A. Beta channel. Current development targets N.I.N.A. Beta 3.2, whereas the release channel 3.1 only has Discord Notification v1.0.0.1

-H