### PR TITLE
NDN-007 | added loggin & fixed small sending bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Discord Notification
 
+## 2.0.0.8
+- Feature: Added additional logging for better traceability and debugging.
+- Bugfix: Implemented today’s date as a fallback when the thread name is empty and resolved several issues related to message sending.
+ 
 ## 2.0.0.7
 - Feature: Added support for using patterns in thread names (e.g., $$FILTER$$).
 - Feature: Added the option “Select Filters to Send Images For” to triggers, allowing multiple filters to be selected for live-stacked image sending.

--- a/Discord/DiscordWebhook.cs
+++ b/Discord/DiscordWebhook.cs
@@ -1,88 +1,121 @@
-﻿
-using System.Threading.Tasks;
-using Discord.Webhook;
-using System;
-using NINA.Core.Utility;
-using Discord;
+﻿using System;
 using System.Collections.Generic;
-using Discord.Net;
 using System.IO;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Net;
+using Discord.Webhook;
+using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
 
 namespace NINA.DiscordNotification.Discord {
-
 	public class DiscordWebhook : IDiscordWebhook {
-
-		private DiscordWebhookClient _discordWebhookClient;
+		private readonly DiscordWebhookClient _discordWebhookClient;
 
 		public DiscordWebhook(string webhookUrl) {
 			try {
-				if (!string.IsNullOrEmpty(webhookUrl)) {
-					_discordWebhookClient = new DiscordWebhookClient(webhookUrl);
+				if (string.IsNullOrWhiteSpace(webhookUrl)) {
+					Logger.Warning("Discord webhook URL is null or empty. Discord webhook client will not be created.");
+					return;
 				}
+
+				_discordWebhookClient = new DiscordWebhookClient(webhookUrl);
 			} catch (HttpException ex) {
-				Logger.Error($"Could not create discord webhook client", ex);
-				throw new Exception(ex.Message);
+				Logger.Error("Could not create discord webhook client due to HttpException.", ex);
+				throw new Exception("Failed to create Discord webhook client: " + ex.Message, ex);
 			} catch (Exception ex) {
-				Logger.Error($"Could not create discord webhook client", ex);
-				throw new Exception(ex.Message);
+				Logger.Error("Could not create discord webhook client due to unexpected exception.", ex);
+				throw new Exception("Failed to create Discord webhook client: " + ex.Message, ex);
 			}
 		}
 
 		public async Task SendMessage(string text = null, IEnumerable<EmbedFieldBuilder> fields = null, IThreadChannel thread = null) {
-			await _SendMessage(text, fields, thread);
+			await _SendMessageAsync(text, fields, thread);
 		}
 
 		public async Task SendFileMessage(string filePath, string text = null, IEnumerable<EmbedFieldBuilder> fields = null, IThreadChannel thread = null) {
-			await _SendFile(filePath, text, fields, thread);
+			await _SendFileAsync(filePath, text, fields, thread);
 		}
 
-		private async Task _SendMessage(string text, IEnumerable<EmbedFieldBuilder> fields, IThreadChannel thread = null) {
+		private async Task _SendMessageAsync(string text, IEnumerable<EmbedFieldBuilder> fields, IThreadChannel thread = null) {
 			try {
+				Logger.Info("Attempting to send Discord message...");
+
 				if (thread != null) {
-					await thread.SendMessageAsync(fields == null ? text : null, embeds: fields != null ? [_BuildEmbeds(text, fields).Build()] : null);
+					await thread.SendMessageAsync(
+						text: fields == null ? text : null,
+						embeds: fields != null ? new[] { _BuildEmbed(text, fields).Build() } : null);
 				} else if (_discordWebhookClient != null) {
-					await _discordWebhookClient.SendMessageAsync(fields == null ? text : null, embeds: fields != null ? [_BuildEmbeds(text, fields).Build()] : null);
+					await _discordWebhookClient.SendMessageAsync(
+						text: fields == null ? text : null,
+						embeds: fields != null ? new[] { _BuildEmbed(text, fields).Build() } : null);
+				} else {
+					Logger.Warning("DiscordWebhookClient and Thread are not set null. Message not sent.");
+					return;
 				}
+
+				Logger.Info("Discord message sent successfully.");
 			} catch (HttpException ex) {
-				Notification.ShowError(ex.Message);
-				Logger.Error($"Could not send message", ex);
+				Notification.ShowError($"Discord API Error: {ex.Message}");
+				Logger.Error("Failed to send Discord message due to HttpException.", ex);
 			} catch (Exception ex) {
-				Notification.ShowError(ex.Message);
-				Logger.Error($"Could not send message", ex);
+				Notification.ShowError($"Error sending Discord message: {ex.Message}");
+				Logger.Error("Failed to send Discord message due to unexpected exception.", ex);
 			}
 		}
 
-		private async Task _SendFile(string filePath, string text, IEnumerable<EmbedFieldBuilder> fields, IThreadChannel thread = null) {
+		private async Task _SendFileAsync(string filePath, string text, IEnumerable<EmbedFieldBuilder> fields, IThreadChannel thread = null) {
 			try {
+				Logger.Info($"Attempting to send Discord file message. File: {filePath}");
+
 				if (thread != null) {
-					await thread.SendFileAsync(filePath, fields == null ? text : null, embeds: fields != null ? [_BuildEmbeds(text, fields).Build()] : null);
+					await thread.SendFileAsync(
+						filePath,
+						text: fields == null ? text : null,
+						embeds: fields != null ? new[] { _BuildEmbed(text, fields).Build() } : null);
 				} else if (_discordWebhookClient != null) {
-					await _discordWebhookClient.SendFileAsync(filePath, fields == null ? text : null, embeds: fields != null ? [_BuildEmbeds(text, fields).Build()] : null);
+					await _discordWebhookClient.SendFileAsync(
+						filePath,
+						text: fields == null ? text : null,
+						embeds: fields != null ? new[] { _BuildEmbed(text, fields).Build() } : null);
+				} else {
+					Logger.Warning("DiscordWebhookClient is null. File message not sent.");
+					return;
 				}
-			} catch (HttpException ex) {
-				if (ex.DiscordCode == DiscordErrorCode.RequestEntityTooLarge) {
-					var fileSize = new FileInfo(filePath).Length / (1024.0 * 1024.0);
-					var errorField = new List<EmbedFieldBuilder>();
-					errorField.AddRange(fields);
-					errorField.Add(
-						new EmbedFieldBuilder {
-							Name = "Image",
-							Value = $"The file is too large ({Math.Round(fileSize, 2)} MB)"
-						});
-					if (thread != null) {
-						await thread.SendMessageAsync(fields == null ? text : null, embeds: errorField != null ? [_BuildEmbeds(text, errorField).Build()] : null);
-					} else {
-						await _discordWebhookClient.SendMessageAsync(fields == null ? text : null, embeds: errorField != null ? [_BuildEmbeds(text, errorField).Build()] : null);
+
+				Logger.Info("Discord file message sent successfully.");
+			} catch (HttpException ex) when (ex.DiscordCode == DiscordErrorCode.RequestEntityTooLarge) {
+				Logger.Warning("Discord file too large to send.");
+				var fileSizeMB = new FileInfo(filePath).Length / (1024.0 * 1024.0);
+
+				var errorFields = new List<EmbedFieldBuilder>(fields ?? Array.Empty<EmbedFieldBuilder>())
+				{
+					new EmbedFieldBuilder
+					{
+						Name = "Image",
+						Value = $"The file is too large ({Math.Round(fileSizeMB, 2)} MB). Please reduce the size."
 					}
+				};
+
+				if (thread != null) {
+					await thread.SendMessageAsync(
+						text: fields == null ? text : null,
+						embeds: new[] { _BuildEmbed(text, errorFields).Build() });
+				} else if (_discordWebhookClient != null) {
+					await _discordWebhookClient.SendMessageAsync(
+						text: fields == null ? text : null,
+						embeds: new[] { _BuildEmbed(text, errorFields).Build() });
 				}
-				Logger.Error($"Could not send file message", ex);
+			} catch (HttpException ex) {
+				Notification.ShowError($"Discord API Error: {ex.Message}");
+				Logger.Error("Failed to send Discord file message due to HttpException.", ex);
 			} catch (Exception ex) {
-				Logger.Error($"Could not send file message", ex);
+				Notification.ShowError($"Error sending Discord file message: {ex.Message}");
+				Logger.Error("Failed to send Discord file message due to unexpected exception.", ex);
 			}
 		}
 
-		private EmbedBuilder _BuildEmbeds(string text, IEnumerable<EmbedFieldBuilder> fields) {
+		private EmbedBuilder _BuildEmbed(string text, IEnumerable<EmbedFieldBuilder> fields) {
 			var embed = new EmbedBuilder {
 				Timestamp = DateTime.UtcNow,
 				Color = Color.Blue,

--- a/DiscordNotificationSequenceItems/DiscordNotificationThreadAfterExposuresTrigger.cs
+++ b/DiscordNotificationSequenceItems/DiscordNotificationThreadAfterExposuresTrigger.cs
@@ -121,6 +121,7 @@ namespace NINA.DiscordNotification.DiscordNotificationSequenceItems {
 			}
 		}
 
+
 		private readonly IImageSaveMediator _imageSaveMediator;
 		private readonly IImageDataFactory _imageDataFactory;
 		private readonly IImagingMediator _imagingMediator;

--- a/Helpers/DiscordTrigger.cs
+++ b/Helpers/DiscordTrigger.cs
@@ -1,5 +1,7 @@
 ﻿using Discord;
 using Discord.WebSocket;
+using Grpc.Core;
+using NINA.Core.Model;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
 using NINA.DiscordNotification.Models;
@@ -8,6 +10,8 @@ using NINA.Image.Interfaces;
 using NINA.Profile.Interfaces;
 using NINA.Sequencer.Interfaces;
 using NINA.Sequencer.SequenceItem;
+using NINA.WPF.Base.Interfaces.Mediator;
+using NINA.WPF.Base.Mediator;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -31,11 +35,8 @@ namespace NINA.DiscordNotification.Helpers {
 
 		private int _exposuresDone;
 		private bool _sendMessage;
-		private bool _initialized;
 		private List<string> _receivedFilters;
 		private bool _isThread;
-		private SendQueue _sendQueue;
-		private SendCommands _sendCommands;
 
 		private readonly IImagingMediator _imagingMediator;
 		private readonly IImageDataFactory _imageDataFactory;
@@ -47,22 +48,17 @@ namespace NINA.DiscordNotification.Helpers {
 			_profileService = profileService;
 		}
 
-		public void Initialize(string Message, bool SendImage, bool UseLiveStackImage, int AfterExposures, string TargetName, ObservableCollection<FilterOption> AvailableFilters) {
-			_Initialize(Message, SendImage, UseLiveStackImage, AfterExposures, TargetName, AvailableFilters);
+		public void Initialize(string message, bool sendImage, bool useLiveStackImage, int afterExposures, string targetName, ObservableCollection<FilterOption> availableFilters) {
+			_Initialize(message, sendImage, useLiveStackImage, afterExposures, targetName, availableFilters);
 		}
 
-		public async Task InitializeThread(string Message, bool SendImage, bool UseLiveStackImage, int AfterExposures, string TargetName, ObservableCollection<FilterOption> AvailableFilters) {
-			_Initialize(Message, SendImage, UseLiveStackImage, AfterExposures, TargetName, AvailableFilters);
-
+		public async Task InitializeThread(string message, bool sendImage, bool useLiveStackImage, int afterExposures, string targetName, ObservableCollection<FilterOption> availableFilters) {
+			_Initialize(message, sendImage, useLiveStackImage, afterExposures, targetName, availableFilters);
 			_isThread = true;
 
 			if (string.IsNullOrEmpty(Properties.Settings.Default.DiscordChannelId)) {
 				Notification.ShowWarning("DiscordChannelId needs to be set");
-				Logger.Info("DiscordChannelId needs to be set");
-				return;
-			}
-
-			if (GeneralHelpers.DiscordSocket == null) {
+				Logger.Warning("DiscordChannelId needs to be set");
 				return;
 			}
 
@@ -78,6 +74,7 @@ namespace NINA.DiscordNotification.Helpers {
 				await GeneralHelpers.DiscordSocket.StartAsync();
 			} catch (Exception ex) {
 				Notification.ShowError(ex.Message);
+				Logger.Error($"Discord login failed: {ex.Message}");
 			}
 		}
 
@@ -88,86 +85,74 @@ namespace NINA.DiscordNotification.Helpers {
 				bool noPendingCommands;
 				bool noLiveStackCommands;
 
-				lock (_sendCommands.SendListLock) {
-					noPendingCommands = _sendCommands.PendingSendCommands.Count == 0;
+				lock (SendCommands.SendListLock) {
+					noPendingCommands = SendCommands.PendingSendCommands.Count == 0;
 				}
 
-				lock (_sendCommands.SendLiveStackListLock) {
-					noLiveStackCommands = _sendCommands.LiveStackCommands.Count == 0;
+				lock (SendCommands.SendLiveStackListLock) {
+					noLiveStackCommands = SendCommands.LiveStackCommands.Count == 0;
 				}
 
-				if (noPendingCommands && noLiveStackCommands && (_sendQueue == null || !_sendQueue.HasPendingItems())) {
+				if (noPendingCommands && noLiveStackCommands && !SendQueue.HasPendingItems()) {
 					break;
-				}
-
-				if (!noLiveStackCommands) {
-					Logger.Debug($"Wait for {_sendCommands.LiveStackCommands.Count} LiveStack-Command(s)...");
 				}
 
 				if (stopwatch.ElapsedMilliseconds > timeout) {
-					Logger.Error("Teardown timeout reached while waiting for pending sends.");
+					Logger.Warning("Teardown timeout reached while waiting for pending sends.");
 					break;
 				}
 
-				await Task.Delay(200);
+				await Task.Delay(200, cancellationToken);
 			}
 
 			await _refreshDiscordSocket();
 
 			_exposuresDone = 0;
 			_sendMessage = false;
-			_initialized = false;
 			_receivedFilters = new List<string>();
-			_isThread = false;
 
-			await _sendQueue?.ShutdownAsync();
-			_sendQueue?.Dispose();
+			await SendQueue.HardResetAsync();
 		}
 
-		public bool ShouldTrigger(ISequenceItem nextItem) {
+		public bool ShouldTrigger(ISequenceItem nextItem = null) {
 			if (nextItem is IExposureItem) {
-				if (_initialized) {
-					_exposuresDone++;
-
-					if ((_exposuresDone % AfterExposures) == 0) {
-						_sendMessage = true;
-						return true;
-					}
+				_exposuresDone++;
+				if ((_exposuresDone % AfterExposures) == 0) {
+					_sendMessage = true;
+					return true;
 				}
 			}
 
 			_sendMessage = false;
-
 			return false;
 		}
 
 		public void Execute() {
-			if (_sendMessage) {
-				if (!UseLiveStackImage) {
-					_sendCommands.AddSendCommand(new SendCommand());
-				} else {
-					_sendCommands.AddLiveStackCommands(new LiveStackSendCommands());
-				}
+			if (!_sendMessage) return;
 
-				Logger.Info($"Execute send discord notification -> use live stacked image:${UseLiveStackImage}");
+			if (!UseLiveStackImage) {
+				SendCommands.AddSendCommand(new SendCommand());
+			} else {
+				SendCommands.AddLiveStackCommands(new LiveStackSendCommands());
 			}
+
+			Logger.Info($"Execute send discord notification -> use live stacked image: {UseLiveStackImage}");
 		}
 
 		public void MessageReceived(IMessage message) {
-			lock (_sendCommands.SendLiveStackListLock) {
-				if (!UseLiveStackImage) {
-					return;
-				}
+			if (!UseLiveStackImage) return;
 
-				var content = message.Content.GetType().GetProperty("Filter");
-				var filter = Regex.Replace(content.GetValue(message.Content).ToString(), $"{ImageHelpers.OSCFILTERPATTERN}$", "");
+			var content = message.Content.GetType().GetProperty("Filter");
+			var filter = Regex.Replace(content.GetValue(message.Content).ToString(), $"{ImageHelpers.OSCFILTERPATTERN}$", "");
 
+			lock (SendCommands.SendLiveStackListLock) {
 				if (!_receivedFilters.Any(f => f == filter)) {
 					_receivedFilters.Add(filter);
-				} else {
-					var cmd = _sendCommands.LiveStackCommands.Dequeue();
+				} else if (SendCommands.LiveStackCommands.Count > 0) {
+					var cmd = SendCommands.LiveStackCommands.Dequeue();
 
-					_receivedFilters.ForEach(receivedFilter => {
+					foreach (var receivedFilter in _receivedFilters) {
+						var progress = new Progress<ApplicationStatus>();
 						var currentFilter = SelectedFilters.FirstOrDefault(sf => sf.IsSelected && sf.Name == GeneralHelpers.FilterPattern);
 						if (currentFilter != null) {
 							cmd.AddLiveStackSendCommand(new LiveStackSendCommand { Filter = currentFilter.Name.Replace(GeneralHelpers.FilterPattern, receivedFilter) });
@@ -177,7 +162,7 @@ namespace NINA.DiscordNotification.Helpers {
 						if (selectedFilter != null) {
 							cmd.AddLiveStackSendCommand(new LiveStackSendCommand { Filter = selectedFilter.Name });
 						}
-					});
+					}
 
 					_receivedFilters = new List<string>();
 					_OnBroadcastTriggered(cmd);
@@ -185,92 +170,90 @@ namespace NINA.DiscordNotification.Helpers {
 			}
 		}
 
-		public void ImageSaved(ImageData ImageData) {
-			if (UseLiveStackImage) {
-				return;
-			}
+		public void ImageSaved(ImageData imageData) {
+			if (UseLiveStackImage) return;
 
-			if (!SendImage) {
-				_sendQueue.EnqueueSend(async () => await new Message(_imagingMediator, _imageDataFactory, _profileService) {
-					Text = Message,
-					TargetName = TargetName,
-					ImageData = ImageData,
-					Filter = ImageData.Filter,
-				}.Send(_isThread));
-				return;
-			}
-
-			_OnBroadcastTriggered(ImageData);
+			_OnBroadcastTriggered(imageData);
 		}
 
 		private void _OnBroadcastTriggered(LiveStackSendCommands cmd) {
-			lock (cmd.SendPendingLiveStackListLock) {
-				if (cmd.PendingLiveStackSendCommands.Count > 0) {
-					var liveStackCmd = cmd.PendingLiveStackSendCommands.Dequeue();
+			void EnqueueNext() {
+				LiveStackSendCommand nextCommand = null;
 
-					liveStackCmd.SendFunc = async () => await _SendLiveStackImage(liveStackCmd.Filter);
-
-					FileInfo latestFile = null;
-
-					bool written = _sendQueue.EnqueueSend(async () => {
-						try {
-							latestFile = await liveStackCmd.SendFunc();
-						} finally {
-							if (latestFile != null && latestFile.Exists) {
-								latestFile.Delete();
-							}
-
-							lock (_sendCommands.SendListLock) {
-								if (cmd.PendingLiveStackSendCommands.Count > 0) {
-									Task.Run(() => _OnBroadcastTriggered(cmd));
-								}
-							}
-						}
-					});
-
-					if (!written) {
-						Logger.Error("Failed to enqueue send task.");
+				lock (cmd.SendPendingLiveStackListLock) {
+					if (cmd.PendingLiveStackSendCommands.Count > 0) {
+						nextCommand = cmd.PendingLiveStackSendCommands.Dequeue();
 					}
 				}
-			}
-		}
 
-		private void _OnBroadcastTriggered(ImageData ImageData = null) {
-			lock (_sendCommands.SendListLock) {
-				if (_sendCommands.PendingSendCommands.Count > 0) {
-					var cmd = _sendCommands.PendingSendCommands.Dequeue();
+				if (nextCommand == null) {
+					return;
+				}
 
-					cmd.SendFunc = async () => await _SendImage(ImageData);
 
-					bool written = _sendQueue.EnqueueSend(async () => {
-						try {
-							await cmd.SendFunc();
-						} finally {
-							lock (_sendCommands.SendListLock) {
-								if (_sendCommands.PendingSendCommands.Count > 0) {
-									Task.Run(() => _OnBroadcastTriggered(ImageData));
-								}
-							}
+				nextCommand.SendFunc = async () => await _SendLiveStackImage(nextCommand.Filter);
+
+				var written = SendQueue.EnqueueSend(async () => {
+					try {
+						var latestFile = await nextCommand.SendFunc();
+
+						if (latestFile != null && latestFile.Exists) {
+							latestFile.Delete();
 						}
-					});
-
-					if (!written) {
-						Logger.Error("Failed to enqueue send task.");
+					} finally {
+						EnqueueNext();
 					}
+				});
+
+				if (!written) {
+					Logger.Error("Failed to enqueue send task.");
 				}
 			}
+
+			EnqueueNext();
 		}
 
-		private async Task<FileInfo> _SendLiveStackImage(string SelectedFilterName) {
+
+		private void _OnBroadcastTriggered(ImageData imageData = null) {
+			void EnqueueNext() {
+				SendCommand cmd = null;
+
+				lock (SendCommands.SendListLock) {
+					if (SendCommands.PendingSendCommands.Count > 0) {
+						cmd = SendCommands.PendingSendCommands.Dequeue();
+					}
+				}
+
+				if (cmd == null) {
+					return;
+				}
+
+				cmd.SendFunc = async () => await _Send(imageData);
+
+				bool written = SendQueue.EnqueueSend(async () => {
+					try {
+						await cmd.SendFunc();
+					} finally {
+						EnqueueNext();
+					}
+				});
+
+				if (!written) {
+					Logger.Error("Failed to enqueue send task.");
+				}
+			}
+
+			EnqueueNext();
+		}
+
+
+		private async Task<FileInfo> _SendLiveStackImage(string selectedFilterName) {
 			FileInfo latestFile = null;
-			var fileName = $"{TargetName}-{SelectedFilterName}";
+			var fileName = $"{TargetName}-{selectedFilterName}";
 
 			try {
-				latestFile = ImageHelpers.WaitForLiveStackFile(Properties.Settings.Default.LiveStackedImageDirectory, ["*.png"], fileName);
-
-				if (string.IsNullOrEmpty(latestFile?.FullName)) {
-					latestFile = ImageHelpers.WaitForLiveStackFile(Properties.Settings.Default.LiveStackedImageDirectory, ["*.fits"], fileName);
-				}
+				latestFile = ImageHelpers.WaitForLiveStackFile(Properties.Settings.Default.LiveStackedImageDirectory, ["*.png"], fileName)
+					?? ImageHelpers.WaitForLiveStackFile(Properties.Settings.Default.LiveStackedImageDirectory, ["*.fits"], fileName);
 
 				if (string.IsNullOrEmpty(latestFile?.FullName)) {
 					Notification.ShowWarning($"No Image from LiveStack found! -> using File Name: {fileName}");
@@ -282,11 +265,11 @@ namespace NINA.DiscordNotification.Helpers {
 					Text = Message,
 					TargetName = TargetName,
 					UseLiveStackedImage = true,
-					Filter = SelectedFilterName
+					Filter = selectedFilterName
 				};
 
 				message.AddExtendedField("File Name", fileName);
-				message.AddExtendedField("Filter", SelectedFilterName);
+				message.AddExtendedField("Filter", selectedFilterName);
 				await message.Send(_isThread, latestFile.FullName);
 
 				return latestFile;
@@ -297,26 +280,31 @@ namespace NINA.DiscordNotification.Helpers {
 			return latestFile;
 		}
 
-		private Task _SendImage(ImageData ImageData) {
-			return new Message(_imagingMediator, _imageDataFactory, _profileService) {
+		private Task _Send(ImageData imageData) {
+			var message = new Message(_imagingMediator, _imageDataFactory, _profileService) {
 				Text = Message,
 				TargetName = TargetName,
-				ImageData = ImageData,
-				Filter = ImageData.Filter,
-			}.Send(_isThread, _profileService.ActiveProfile.ImageFileSettings.FilePath);
+				ImageData = imageData,
+				Filter = imageData.Filter,
+			};
+
+			if (SendImage) {
+				return message.Send(_isThread, _profileService.ActiveProfile.ImageFileSettings.FilePath);
+			}
+
+			return message.Send(_isThread);
 		}
 
-		private void _Initialize(string Message, bool SendImage, bool UseLiveStackImage, int AfterExposures, string TargetName, ObservableCollection<FilterOption> AvailableFilters) {
-			_sendQueue = new SendQueue();
-			_sendCommands = new SendCommands();
-			_initialized = true;
+		private void _Initialize(string message, bool sendImage, bool useLiveStackImage, int afterExposures, string targetName, ObservableCollection<FilterOption> availableFilters) {
+			SendCommands.ClearAll();
+
 			_receivedFilters = new List<string>();
-			this.TargetName = TargetName;
-			this.Message = Message;
-			this.SendImage = SendImage;
-			this.UseLiveStackImage = UseLiveStackImage;
-			this.AfterExposures = AfterExposures;
-			this.SelectedFilters = AvailableFilters.Where(filter => filter.IsSelected).ToList();
+			TargetName = string.IsNullOrEmpty(targetName) ? "No_target" : targetName;
+			Message = message;
+			SendImage = sendImage;
+			UseLiveStackImage = useLiveStackImage;
+			AfterExposures = afterExposures;
+			SelectedFilters = availableFilters.Where(filter => filter.IsSelected).ToList();
 		}
 
 		private async Task _refreshDiscordSocket() {

--- a/Helpers/GeneralHelpers.cs
+++ b/Helpers/GeneralHelpers.cs
@@ -57,13 +57,15 @@ namespace NINA.DiscordNotification.Helpers {
 		}
 
 		public static string DefineThreadName(string targetName, string filter) {
-			if (string.IsNullOrEmpty(Properties.Settings.Default.ThreadNameTemplate)) {
-				return "";
-			}
 			DateTime now = DateTime.Now;
-			string dateMinus12 = now.TimeOfDay >= TimeSpan.FromHours(12) ? now.ToLocalTime().AddHours(-12).ToString("yyyy-MM-dd") : now.ToLocalTime().AddDays(-1).ToString("yyyy-MM-dd");
+			var today = now.ToLocalTime().ToString("yyyy-MM-dd");
+			if (string.IsNullOrEmpty(Properties.Settings.Default.ThreadNameTemplate)) {
+				return today;
+			}
 
-			return Properties.Settings.Default.ThreadNameTemplate.Replace(TargetPattern, targetName).Replace(FilterPattern, filter).Replace(DateMinus12Pattern, dateMinus12).Replace(DatePattern, now.ToLocalTime().ToString("yyyy-MM-dd")).Replace(DateTimePattern, now.ToLocalTime().ToString("yyyy-MM-dd_HH-mm")).Replace(TimePattern, now.ToLocalTime().ToString("HH-mm"));
+			string dateMinus12 = now.TimeOfDay >= TimeSpan.FromHours(12) ? now.ToLocalTime().AddHours(-12).ToString("yyyy-MM-dd") : now.ToLocalTime().AddDays(-1).ToString("yyyy-MM-dd");
+			var formatttedThreadName = Properties.Settings.Default.ThreadNameTemplate.Replace(TargetPattern, targetName).Replace(FilterPattern, filter).Replace(DateMinus12Pattern, dateMinus12).Replace(DatePattern, today).Replace(DateTimePattern, now.ToLocalTime().ToString("yyyy-MM-dd_HH-mm")).Replace(TimePattern, now.ToLocalTime().ToString("HH-mm"));
+			return string.IsNullOrEmpty(formatttedThreadName) ? today : formatttedThreadName;
 		}
 
 		public static async Task<IThreadChannel> InitDiscordSocket(string threadName, string id) {

--- a/Helpers/SendQueue.cs
+++ b/Helpers/SendQueue.cs
@@ -6,27 +6,36 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 
-public class SendCommands {
-	public readonly object SendListLock = new();
-	public readonly object SendLiveStackListLock = new object();
-	public readonly Queue<SendCommand> PendingSendCommands = new();
-	public readonly Queue<LiveStackSendCommands> LiveStackCommands = new();
+public static class SendCommands {
+	public static readonly object SendListLock = new();
+	public static readonly object SendLiveStackListLock = new();
+	public static readonly Queue<SendCommand> PendingSendCommands = new();
+	public static readonly Queue<LiveStackSendCommands> LiveStackCommands = new();
 
-	public void AddSendCommand(SendCommand cmd) {
+	public static void AddSendCommand(SendCommand cmd) {
 		lock (SendListLock) {
 			PendingSendCommands.Enqueue(cmd);
 		}
 	}
 
-	public void AddLiveStackCommands(LiveStackSendCommands cmd) {
+	public static void AddLiveStackCommands(LiveStackSendCommands cmd) {
 		lock (SendLiveStackListLock) {
 			LiveStackCommands.Enqueue(cmd);
+		}
+	}
+
+	public static void ClearAll() {
+		lock (SendListLock) {
+			PendingSendCommands.Clear();
+		}
+		lock (SendLiveStackListLock) {
+			LiveStackCommands.Clear();
 		}
 	}
 }
 
 public class LiveStackSendCommands {
-	public readonly object SendPendingLiveStackListLock = new object();
+	public readonly object SendPendingLiveStackListLock = new();
 	public readonly Queue<LiveStackSendCommand> PendingLiveStackSendCommands = new();
 
 	public void AddLiveStackSendCommand(LiveStackSendCommand cmd) {
@@ -45,31 +54,41 @@ public class LiveStackSendCommand {
 	public string Filter { get; init; }
 }
 
-public class SendQueue : IDisposable {
-	private readonly Channel<Func<Task>> _sendChannel;
-	private readonly Task _worker;
-	private readonly CancellationTokenSource _cts = new CancellationTokenSource();
-	private int _queueCount = 0;
+public static class SendQueue {
+	private static Channel<Func<Task>> _sendChannel;
+	private static Task _worker;
+	private static CancellationTokenSource _cts;
+	private static int _queueCount = 0;
+	private static readonly object _lock = new();
 
-	public SendQueue() {
+	static SendQueue() {
+		InitializeChannelAndWorker();
+	}
+
+	private static void InitializeChannelAndWorker() {
+		_cts = new CancellationTokenSource();
 		_sendChannel = Channel.CreateUnbounded<Func<Task>>(new UnboundedChannelOptions {
 			SingleReader = true,
 			SingleWriter = false
 		});
-
 		_worker = Task.Run(() => ProcessQueueAsync(_cts.Token));
+		_queueCount = 0;
 	}
 
-	public bool EnqueueSend(Func<Task> sendFunc) {
-		bool written = _sendChannel.Writer.TryWrite(sendFunc);
-		if (written) {
-			Interlocked.Increment(ref _queueCount);
+	public static bool EnqueueSend(Func<Task> sendFunc) {
+		lock (_lock) {
+			if (_cts == null || _cts.IsCancellationRequested) {
+				return false;
+			}
+			bool written = _sendChannel.Writer.TryWrite(sendFunc);
+			if (written) {
+				Interlocked.Increment(ref _queueCount);
+			}
+			return written;
 		}
-
-		return written;
 	}
 
-	private async Task ProcessQueueAsync(CancellationToken cancellationToken) {
+	private static async Task ProcessQueueAsync(CancellationToken cancellationToken) {
 		try {
 			await foreach (var sendFunc in _sendChannel.Reader.ReadAllAsync(cancellationToken)) {
 				try {
@@ -81,26 +100,45 @@ public class SendQueue : IDisposable {
 				}
 			}
 		} catch (OperationCanceledException) {
-			Logger.Error("SendQueue has been canceled");
+			Logger.Warning("SendQueue has been canceled");
 		}
 	}
 
-	public bool HasPendingItems() {
+	public static bool HasPendingItems() {
 		return Volatile.Read(ref _queueCount) > 0;
 	}
 
-	public async Task ShutdownAsync() {
-		_sendChannel.Writer.Complete();
+	public static async Task ShutdownAsync() {
+		lock (_lock) {
+			if (_cts == null || _cts.IsCancellationRequested)
+				return;
+
+			_sendChannel.Writer.Complete();
+			_cts.Cancel();
+		}
 
 		try {
 			await _worker;
 		} catch {
 			Logger.Error("Error while shutting down SendQueue");
 		}
+
+		lock (_lock) {
+			_cts.Dispose();
+			_cts = null;
+			_worker = null;
+			_sendChannel = null;
+			_queueCount = 0;
+		}
 	}
 
-	public void Dispose() {
-		_cts.Cancel();
-		_cts.Dispose();
+	public static async Task HardResetAsync() {
+		await ShutdownAsync();
+
+		lock (_lock) {
+			SendCommands.ClearAll();
+
+			InitializeChannelAndWorker();
+		}
 	}
 }

--- a/Models/Message.cs
+++ b/Models/Message.cs
@@ -1,4 +1,5 @@
 ﻿using Discord;
+using NINA.Core.Model;
 using NINA.Core.Utility;
 using NINA.Core.Utility.Notification;
 using NINA.DiscordNotification.Helpers;
@@ -24,7 +25,7 @@ namespace NINA.DiscordNotification.Models {
 
 		private string _filePath;
 
-		private Dictionary<string, object> _extendedFields = new();
+		private readonly Dictionary<string, object> _extendedFields = new();
 		private Dictionary<string, object> ExtendedFields {
 			get {
 				var baseFields = ImageData?.GetExtendedImageData() ?? new Dictionary<string, object>();
@@ -45,92 +46,112 @@ namespace NINA.DiscordNotification.Models {
 		}
 
 		public void AddExtendedField(string key, object value) {
-			_extendedFields.Add(key, value);
+			if (string.IsNullOrWhiteSpace(key)) {
+				Logger.Warning("Attempted to add extended field with null or whitespace key.");
+				return;
+			}
+
+			_extendedFields[key] = value;
 		}
 
 		public async Task Send(bool isThread, string path) {
 			try {
+				Logger.Info("Starting send process...");
+
 				object image = null;
-				var sendStopwatch = new Stopwatch();
+				var sendStopwatch = Stopwatch.StartNew();
 
 				if (!UseLiveStackedImage) {
 					_filePath = Path.Combine(path, $"image_{Guid.NewGuid()}.jpeg");
 					image = await _imageDataFactory.RenderImage(ImageData, _profileService.ActiveProfile.CameraSettings);
 				} else {
-					_filePath = Path.Combine(Path.GetDirectoryName(path), $"image_{Guid.NewGuid()}.jpeg");
+					var directory = Path.GetDirectoryName(path) ?? path;
+					_filePath = Path.Combine(directory, $"image_{Guid.NewGuid()}.jpeg");
 
-					if (path.CheckExtensions([".fits"])) {
+					if (path.CheckExtensions(new[] { ".fits" })) {
 						image = await FITS.Load(new Uri(path), false, _imageDataFactory, CancellationToken.None);
 					}
 				}
 
-				if (UseLiveStackedImage && path.CheckExtensions([".png", ".jpeg", ".jpeg"])) {
+				if (UseLiveStackedImage && path.CheckExtensions(new[] { ".png", ".jpeg", ".jpg" })) {
 					path.EncodeImage(_filePath);
-				} else if (image != null) {
-					(await _imagingMediator.PrepareImage((IImageData)image, _imageParameters, CancellationToken.None)).EncodeImage(_filePath);
+				} else if (image is IImageData imageData) {
+					var preparedImage = await _imagingMediator.PrepareImage(imageData, _imageParameters, CancellationToken.None);
+					preparedImage.EncodeImage(_filePath);
 				}
 
-				sendStopwatch.Start();
 				await Send(isThread);
+
 				sendStopwatch.Stop();
 
-				if (_filePath != null && File.Exists(_filePath)) {
-					File.Delete(_filePath);
+				if (!string.IsNullOrEmpty(_filePath) && File.Exists(_filePath)) {
+					try {
+						File.Delete(_filePath);
+					} catch (Exception ex) {
+						Logger.Warning($"Could not delete temp file '{_filePath}': {ex.Message}");
+					}
 				}
-				Logger.Info($"Image send time={sendStopwatch.ElapsedMilliseconds}ms");
+
+				Logger.Info($"Image send completed in {sendStopwatch.ElapsedMilliseconds} ms.");
 			} catch (Exception ex) {
-				Notification.ShowWarning("Exception: " + ex);
-				Logger.Error(ex);
+				Notification.ShowWarning("Exception during send: " + ex.Message);
+				Logger.Error("Exception during send:", ex);
 			}
 		}
 
-		public async Task Send(bool isThread) {
-			async Task ExecuteSend(bool isThread) {
-				IThreadChannel thread = isThread ? await GetThread() : null;
-
-				if (_filePath != null) {
-					await GeneralHelpers.DiscordWebhook.SendFileMessage(_filePath, Text, _GetEmbedFields(), thread);
-					return;
-				}
-				await GeneralHelpers.DiscordWebhook.SendMessage(Text, _GetEmbedFields(), thread);
-			}
-
-			async Task<IThreadChannel> GetThread() {
-				if (GeneralHelpers.DiscordSocket.ConnectionState == ConnectionState.Connected) {
-					return await GeneralHelpers.InitDiscordSocket(GeneralHelpers.DefineThreadName(TargetName, Filter), Properties.Settings.Default.DiscordChannelId);
-				}
-
-				var taskCompletion = new TaskCompletionSource<IThreadChannel>();
-
-				Task Handler() {
-					GeneralHelpers.DiscordSocket.Ready -= Handler;
-
-					_ = Task.Run(async () => {
-						var thread = await GeneralHelpers.InitDiscordSocket(GeneralHelpers.DefineThreadName(TargetName, Filter), Properties.Settings.Default.DiscordChannelId);
-
-						taskCompletion.SetResult(thread);
-					});
-
-					return Task.CompletedTask;
-				}
-
-				GeneralHelpers.DiscordSocket.Ready += Handler;
-
-				return await taskCompletion.Task;
-			}
-
+		public async Task<bool> Send(bool isThread) {
 			try {
-				await ExecuteSend(isThread);
+				IThreadChannel thread = null;
+
+				if (isThread) {
+					thread = await GetThreadAsync();
+				}
+
+				if (!string.IsNullOrEmpty(_filePath) && File.Exists(_filePath)) {
+					await GeneralHelpers.DiscordWebhook.SendFileMessage(_filePath, Text, _GetEmbedFields(), thread);
+				} else {
+					await GeneralHelpers.DiscordWebhook.SendMessage(Text, _GetEmbedFields(), thread);
+				}
 			} catch (Exception ex) {
-				Notification.ShowWarning("Exception: " + ex);
-				Logger.Error(ex);
+				Notification.ShowWarning("Exception during Discord send: " + ex.Message);
+				Logger.Error("Exception during Discord send:", ex);
+				return false;
 			}
+
+			return true;
+		}
+
+		private async Task<IThreadChannel> GetThreadAsync() {
+			if (GeneralHelpers.DiscordSocket.ConnectionState == ConnectionState.Connected) {
+				return await GeneralHelpers.InitDiscordSocket(GeneralHelpers.DefineThreadName(TargetName, Filter), Properties.Settings.Default.DiscordChannelId);
+			}
+
+			var tcs = new TaskCompletionSource<IThreadChannel>();
+
+			Task Handler() {
+				GeneralHelpers.DiscordSocket.Ready -= Handler;
+
+				_ = Task.Run(async () => {
+					try {
+						var thread = await GeneralHelpers.InitDiscordSocket(GeneralHelpers.DefineThreadName(TargetName, Filter), Properties.Settings.Default.DiscordChannelId);
+						tcs.SetResult(thread);
+					} catch (Exception ex) {
+						tcs.SetException(ex);
+					}
+				});
+
+				return Task.CompletedTask;
+			}
+
+			GeneralHelpers.DiscordSocket.Ready += Handler;
+
+			return await tcs.Task;
 		}
 
 		private List<EmbedFieldBuilder> _GetEmbedFields() {
 			var fields = new List<EmbedFieldBuilder>();
 
-			if (!string.IsNullOrEmpty(TargetName)) {
+			if (!string.IsNullOrWhiteSpace(TargetName)) {
 				fields.Add(new EmbedFieldBuilder {
 					Name = "Target",
 					Value = TargetName

--- a/Options.xaml.cs
+++ b/Options.xaml.cs
@@ -7,7 +7,6 @@ using NINA.DiscordNotification.Helpers;
 using Discord.WebSocket;
 using Discord;
 using Discord.Net;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace NINA.DiscordNotification {
@@ -20,12 +19,15 @@ namespace NINA.DiscordNotification {
 
 		private async void TestDiscordWebhook(object sender, RoutedEventArgs e) {
 			try {
-				await new Message(null, null, null) {
+				var success = await new Message(null, null, null) {
 					Text = "This is a message for testing",
 					TargetName = "Test",
 					Filter = null
 				}.Send(false);
-				Notification.ShowSuccess("Message successfully sent");
+
+				if (success) {
+					Notification.ShowSuccess("Message successfully sent");
+				}
 			} catch (Exception ex) {
 				Notification.ShowError(ex.Message);
 			}
@@ -44,7 +46,7 @@ namespace NINA.DiscordNotification {
 
 				GeneralHelpers.DiscordSocket.Ready += async () => {
 					try {
-						var result = await GeneralHelpers.InitDiscordSocket("Test", Properties.Settings.Default.DiscordChannelId);
+						var result = await GeneralHelpers.InitDiscordSocket(GeneralHelpers.DefineThreadName(GeneralHelpers.TimePattern, null), Properties.Settings.Default.DiscordChannelId);
 						if (result != null) {
 							Notification.ShowSuccess("Thread successfully created");
 						}

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("2.0.0.7")]
-[assembly: AssemblyFileVersion("2.0.0.7")]
+[assembly: AssemblyVersion("2.0.0.8")]
+[assembly: AssemblyFileVersion("2.0.0.8")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Discord Notification")]
@@ -64,8 +64,16 @@ The plugin also includes a trigger that can automatically create a new Discord t
 ### Beta vs Release Channel
 - Discord Notification's current versions require N.I.N.A 3.2, which is currently in the Beta release channel. Basic functionality from verison 1.0.0.1 is available in the N.I.N.A. 3.1 Release channel.
 
+### Information
+- If the thread name is left empty, the current date will automatically be used as a fallback value.
+
 ## LiveStack
 - The LiveStack image feature needs the 'LiveStack' plugin to be installed and configured as shown in the screenshots below.
+### Important!
+- The plugin must have live stacking started before images can be sent.
+- You should also configure a minimum delay of 60 seconds after the exposures are finished, before stopping the live stacking process.
+- The “LiveStacked Image Path” must be set to the folder where the stacked files created by the LiveStack plugin are stored.
+- To ensure reliable sending of live stacked images, it is recommended to use at least 4 iterations of the loop condition.
 
 ## General Options
 - **Discord Webhook URL:**

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ The plugin also includes a trigger that can automatically create a new Discord t
 ### Beta vs Release Channel
 - Discord Notification's current versions require N.I.N.A 3.2, which is currently in the Beta release channel. Basic functionality from verison 1.0.0.1 is available in the N.I.N.A. 3.1 Release channel.
 
+### Information
+- If the thread name is left empty, the current date will automatically be used as a fallback value.
+
 ## LiveStack
 - The LiveStack image feature needs the 'LiveStack' plugin to be installed and configured as shown in the screenshots below.
+### Important!
+- The plugin must have live stacking started before images can be sent.
+- You should also configure a minimum delay of 60 seconds after the exposures are finished, before stopping the live stacking process.
+- The “LiveStacked Image Path” must be set to the folder where the stacked files created by the LiveStack plugin are stored.
+- To ensure reliable sending of live stacked images, it is recommended to use at least 4 iterations of the loop condition.
 
 ## General Options
 - **Discord Webhook URL:**


### PR DESCRIPTION
- Feature: Added additional logging for better traceability and debugging.
- Bugfix: Implemented today’s date as a fallback when the thread name is empty and resolved several issues related to message sending.

### Important!
- The plugin must have live stacking started before images can be sent.
- You should also configure a minimum delay of 60 seconds after the exposures are finished, before stopping the live stacking process.
- The “LiveStacked Image Path” must be set to the folder where the stacked files created by the LiveStack plugin are stored.
- To ensure reliable sending of live stacked images, it is recommended to use at least 4 iterations of the loop condition